### PR TITLE
Remove slash to ignore paths

### DIFF
--- a/realize/watcher.go
+++ b/realize/watcher.go
@@ -205,7 +205,6 @@ func (p *Project) fmt() error {
 // Ignore validates a path
 func (p *Project) ignore(str string) bool {
 	for _, v := range p.Watcher.Ignore {
-		v = slash(v)
 		if strings.Contains(str, p.base+v) {
 			return true
 		}


### PR DESCRIPTION
It is not necessary add a slash for ignore paths because the p.base already has an slash to the end.