### PR TITLE
Store configuration in subdirectory

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -33,7 +33,7 @@ type Resources struct {
 // Read from the configuration file
 func (s *Settings) Read(out interface{}) error {
 	localConfigPath := s.Resources.Config
-	if _, err := os.Stat(".realize/"); err == nil {
+	if _, err := os.Stat(".realize/" + s.Resources.Config); err == nil {
 		localConfigPath = ".realize/" + s.Resources.Config
 	}
 	content, err := s.Stream(localConfigPath)


### PR DESCRIPTION
I try to keep the project root clean from configuration files. Thus I store tool related configs whenever possible in a sub directory. This stores the config in a .realize sub directory while still reading the old config if this directory does not exist