### PR TITLE
resolve windows issues

### DIFF
--- a/watcher/cmd.go
+++ b/watcher/cmd.go
@@ -28,7 +28,7 @@ func (h *Blueprint) Run() error {
 func (h *Blueprint) Add(p *cli.Context) error {
 	project := Project{
 		Name:   h.name(p),
-		Path:   filepath.Clean(p.String("path")),
+		Path:   strings.Replace(filepath.Clean(p.String("path")), "\\", "/", -1),
 		Build:  p.Bool("build"),
 		Bin:    !p.Bool("no-bin"),
 		Run:    !p.Bool("no-run"),

--- a/watcher/exec.go
+++ b/watcher/exec.go
@@ -34,6 +34,8 @@ func (p *Project) goRun(channel chan bool, runner chan bool, wr *sync.WaitGroup)
 	} else {
 		if _, err := os.Stat(filepath.Join(os.Getenv("GOBIN"), filepath.Base(p.path))); err == nil {
 			build = exec.Command(filepath.Join(os.Getenv("GOBIN"), filepath.Base(p.path)), params...)
+		} else if _, err := os.Stat(filepath.Join(os.Getenv("GOBIN"), filepath.Base(p.path)) + ".exe"); err == nil {
+			build = exec.Command(filepath.Join(os.Getenv("GOBIN"), filepath.Base(p.path)) + ".exe", params...)
 		} else {
 			p.Buffer.StdLog = append(p.Buffer.StdLog, BufferOut{Time: time.Now(), Text: "Can't run a not compiled project"})
 			p.Fatal(err, "Can't run a not compiled project", ":")


### PR DESCRIPTION
Before:

```
?[33m[?[0m23:25:14?[33m]?[0m?[33m[?[0mEXAMPLE?[33m]?[0m : Running..
?[33m[?[0m23:25:14?[33m]?[0m?[31mCan't run a not compiled project:?[0m GetFileAttributesEx C:\workspace\go\bin\example: The system cannot find the file specified.
```

Now:

```
?[33m[?[0m23:27:57?[33m]?[0m?[33m[?[0mEXAMPLE?[33m]?[0m : ?[34;1mWatching?[0m ?[35;1m1?[0m file/s ?[35;1m1?[0m folder/s
?[33m[?[0m23:27:57?[33m]?[0m?[33m[?[0mEXAMPLE?[33m]?[0m : Installing..
?[33m[?[0m23:27:57?[33m]?[0m?[33m[?[0m?[32;1mEXAMPLE?[0m?[33m]?[0m : ?[32mInstalled?[0m after ?[35m0.240 s?[0m
?[33m[?[0m23:27:57?[33m]?[0m?[33m[?[0mEXAMPLE?[33m]?[0m : Running..
?[33m[?[0m23:27:57?[33m]?[0m?[33m[?[0m?[32;1mEXAMPLE?[0m?[33m]?[0m : ?[32mHas been run?[0m after ?[35m0.001 s?[0m
?[33m[?[0m23:28:02?[33m]?[0m?[33m[?[0m?[35;1mEXAMPLE?[0m?[33m]?[0m : ?[35;1mGO changed?[0m ?[35;1mC:\workspace\go\src\github.com\tockins\realize\example\main.go?[0m
```

Sorry for broken color codes...windows...