### PR TITLE
Fix broken color codes on Windows

### DIFF
--- a/realize.go
+++ b/realize.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/tockins/interact"
 	"github.com/tockins/realize/server"
 	"github.com/tockins/realize/settings"
 	"github.com/tockins/realize/style"
 	"github.com/tockins/realize/watcher"
+	"github.com/tockins/interact"
 	cli "gopkg.in/urfave/cli.v2"
 )
 
@@ -167,14 +167,14 @@ func main() {
 					&cli.BoolFlag{Name: "no-config", Aliases: []string{"nc"}, Value: false, Usage: "Ignore existing configurations."},
 				},
 				Action: func(p *cli.Context) error {
-					fmt.Println(p.String("path"))
+					fmt.Fprintln(style.Output, p.String("path"))
 					if err := r.Blueprint.Add(p); err != nil {
 						return err
 					}
 					if err := r.Record(r); err != nil {
 						return err
 					}
-					fmt.Println(style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Your project was successfully added."))
+					fmt.Fprintln(style.Output, style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Your project was successfully added."))
 					return nil
 				},
 				Before: before,
@@ -903,7 +903,7 @@ func main() {
 					if err := r.Record(r); err != nil {
 						return err
 					}
-					fmt.Println(style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Your configuration was successful."))
+					fmt.Fprintln(style.Output, style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Your configuration was successful."))
 					return nil
 				},
 				Before: before,
@@ -923,7 +923,7 @@ func main() {
 					if err := r.Record(r); err != nil {
 						return err
 					}
-					fmt.Println(style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Your project was successfully removed."))
+					fmt.Fprintln(style.Output, style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Your project was successfully removed."))
 					return nil
 				},
 				Before: before,
@@ -947,7 +947,7 @@ func main() {
 					if err := r.Settings.Remove(settings.Directory); err != nil {
 						return err
 					}
-					fmt.Println(style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Realize folder successfully removed."))
+					fmt.Fprintln(style.Output, style.Yellow.Bold("[")+"REALIZE"+style.Yellow.Bold("]"), style.Green.Bold("Realize folder successfully removed."))
 					return nil
 				},
 				Before: before,
@@ -955,7 +955,7 @@ func main() {
 		},
 	}
 	if err := app.Run(os.Args); err != nil {
-		fmt.Println(style.Red.Bold(err))
+		fmt.Fprintln(style.Output, style.Red.Bold(err))
 		os.Exit(1)
 	}
 }

--- a/style/style.go
+++ b/style/style.go
@@ -22,3 +22,7 @@ var (
 	Magenta = colorBase(color.FgMagenta)
 	Green   = colorBase(color.FgGreen)
 )
+
+// Output defines the standard output of the print functions. By default, os.Stdout is used.
+// When invoked on Windows machines, this automatically handles escape sequences.
+var Output = color.Output

--- a/watcher/cmd.go
+++ b/watcher/cmd.go
@@ -135,48 +135,48 @@ func (h *Blueprint) List() error {
 	err := h.check()
 	if err == nil {
 		for _, val := range h.Projects {
-			fmt.Println(style.Blue.Bold("[") + strings.ToUpper(val.Name) + style.Blue.Bold("]"))
+			fmt.Fprintln(style.Output, style.Blue.Bold("[")+strings.ToUpper(val.Name)+style.Blue.Bold("]"))
 			name := style.Magenta.Bold("[") + strings.ToUpper(val.Name) + style.Magenta.Bold("]")
 
-			fmt.Println(name, style.Yellow.Regular("Base Path"), ":", style.Magenta.Regular(val.Path))
-			fmt.Println(name, style.Yellow.Regular("Fmt"), ":", style.Magenta.Regular(val.Cmds.Fmt))
-			fmt.Println(name, style.Yellow.Regular("Generate"), ":", style.Magenta.Regular(val.Cmds.Generate))
-			fmt.Println(name, style.Yellow.Regular("Test"), ":", style.Magenta.Regular(val.Cmds.Test))
-			fmt.Println(name, style.Yellow.Regular("Install"), ":", style.Magenta.Regular(val.Cmds.Bin))
-			fmt.Println(name, style.Yellow.Regular("Build"), ":", style.Magenta.Regular(val.Cmds.Build))
-			fmt.Println(name, style.Yellow.Regular("Run"), ":", style.Magenta.Regular(val.Cmds.Run))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Base Path"), ":", style.Magenta.Regular(val.Path))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Fmt"), ":", style.Magenta.Regular(val.Cmds.Fmt))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Generate"), ":", style.Magenta.Regular(val.Cmds.Generate))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Test"), ":", style.Magenta.Regular(val.Cmds.Test))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Install"), ":", style.Magenta.Regular(val.Cmds.Bin))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Build"), ":", style.Magenta.Regular(val.Cmds.Build))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Run"), ":", style.Magenta.Regular(val.Cmds.Run))
 			if len(val.Args) > 0 {
-				fmt.Println(name, style.Yellow.Regular("Params"), ":", style.Magenta.Regular(val.Args))
+				fmt.Fprintln(style.Output, name, style.Yellow.Regular("Params"), ":", style.Magenta.Regular(val.Args))
 			}
-			fmt.Println(name, style.Yellow.Regular("Watcher"), ":")
-			fmt.Println(name, "\t", style.Yellow.Regular("Preview"), ":", style.Magenta.Regular(val.Watcher.Preview))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Watcher"), ":")
+			fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("Preview"), ":", style.Magenta.Regular(val.Watcher.Preview))
 			if len(val.Watcher.Exts) > 0 {
-				fmt.Println(name, "\t", style.Yellow.Regular("Extensions"), ":", style.Magenta.Regular(val.Watcher.Exts))
+				fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("Extensions"), ":", style.Magenta.Regular(val.Watcher.Exts))
 			}
 			if len(val.Watcher.Paths) > 0 {
-				fmt.Println(name, "\t", style.Yellow.Regular("Paths"), ":", style.Magenta.Regular(val.Watcher.Paths))
+				fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("Paths"), ":", style.Magenta.Regular(val.Watcher.Paths))
 			}
 			if len(val.Watcher.Ignore) > 0 {
-				fmt.Println(name, "\t", style.Yellow.Regular("Ignored paths"), ":", style.Magenta.Regular(val.Watcher.Ignore))
+				fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("Ignored paths"), ":", style.Magenta.Regular(val.Watcher.Ignore))
 			}
 			if len(val.Watcher.Scripts) > 0 {
-				fmt.Println(name, "\t", style.Yellow.Regular("Scripts"), ":")
+				fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("Scripts"), ":")
 				for _, v := range val.Watcher.Scripts {
 					if v.Command != "" {
-						fmt.Println(name, "\t\t", style.Magenta.Regular("-"), style.Yellow.Regular("Command"), ":", style.Magenta.Regular(v.Command))
+						fmt.Fprintln(style.Output, name, "\t\t", style.Magenta.Regular("-"), style.Yellow.Regular("Command"), ":", style.Magenta.Regular(v.Command))
 						if v.Path != "" {
-							fmt.Println(name, "\t\t", style.Yellow.Regular("Path"), ":", style.Magenta.Regular(v.Path))
+							fmt.Fprintln(style.Output, name, "\t\t", style.Yellow.Regular("Path"), ":", style.Magenta.Regular(v.Path))
 						}
 						if v.Type != "" {
-							fmt.Println(name, "\t\t", style.Yellow.Regular("Type"), ":", style.Magenta.Regular(v.Type))
+							fmt.Fprintln(style.Output, name, "\t\t", style.Yellow.Regular("Type"), ":", style.Magenta.Regular(v.Type))
 						}
 					}
 				}
 			}
-			fmt.Println(name, style.Yellow.Regular("Streams"), ":")
-			fmt.Println(name, "\t", style.Yellow.Regular("File Out"), ":", style.Magenta.Regular(val.Streams.FileOut))
-			fmt.Println(name, "\t", style.Yellow.Regular("File Log"), ":", style.Magenta.Regular(val.Streams.FileLog))
-			fmt.Println(name, "\t", style.Yellow.Regular("File Err"), ":", style.Magenta.Regular(val.Streams.FileErr))
+			fmt.Fprintln(style.Output, name, style.Yellow.Regular("Streams"), ":")
+			fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("File Out"), ":", style.Magenta.Regular(val.Streams.FileOut))
+			fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("File Log"), ":", style.Magenta.Regular(val.Streams.FileLog))
+			fmt.Fprintln(style.Output, name, "\t", style.Yellow.Regular("File Err"), ":", style.Magenta.Regular(val.Streams.FileErr))
 		}
 		return nil
 	}

--- a/watcher/utils.go
+++ b/watcher/utils.go
@@ -46,7 +46,7 @@ func inArray(str string, list []string) bool {
 
 // Rewrite the layout of the log timestamp
 func (w logWriter) Write(bytes []byte) (int, error) {
-	return fmt.Print(style.Yellow.Regular("[") + time.Now().Format("15:04:05") + style.Yellow.Regular("]") + string(bytes))
+	return fmt.Fprint(style.Output, style.Yellow.Regular("[")+time.Now().Format("15:04:05")+style.Yellow.Regular("]")+string(bytes))
 }
 
 // getEnvPath returns the first path found in env or empty string

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -414,7 +414,7 @@ func (p *Project) print(t string, o BufferOut, msg string, stream string) {
 		log.Print(msg)
 	}
 	if stream != "" {
-		fmt.Print(stream)
+		fmt.Fprint(style.Output, stream)
 	}
 	go func() {
 		p.parent.Sync <- "sync"


### PR DESCRIPTION
Solves issue https://github.com/tockins/realize/issues/83

All the code has been ran through `go fmt`, which caused some of the imports to become alphabetized and the spaces around the string additions to go away. I hope you don't mind. I can always change them back if need be.

All the tests passed and it even worked on my local machine, so I'm pretty confident these changes don't break anything.

![realize-colors](https://user-images.githubusercontent.com/941763/29910758-02db2294-8de0-11e7-8cf8-31da073a693f.PNG)