### PR TITLE
include hidden files in watch

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/fsnotify/fsnotify"
 	"log"
 	"math/big"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 var (
@@ -315,7 +316,7 @@ func (p *Project) walk(path string, info os.FileInfo, err error) error {
 			return nil
 		}
 	}
-	if !strings.Contains(path, "/.") && !strings.HasPrefix(path, ".") && (info.IsDir() || array(ext(path), p.Watcher.Exts)) {
+	if !strings.HasPrefix(path, ".") && (info.IsDir() || array(ext(path), p.Watcher.Exts)) {
 		result := p.watcher.Walk(path, p.init)
 		if result != "" {
 			if info.IsDir() {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,1 +1,72 @@
 package main
+
+import (
+	"testing"
+
+	"os"
+)
+
+type fileWatcherMock struct {
+	FileWatcher
+}
+
+func (f *fileWatcherMock) Walk(path string, _ bool) string {
+	return path
+}
+
+type fileInfoMock struct {
+	os.FileInfo
+	FileIsDir bool
+}
+
+func (m *fileInfoMock) IsDir() bool { return m.FileIsDir }
+
+func TestWalk(t *testing.T) {
+	p := Project{
+		Name: "Test Project",
+		Watcher: Watch{
+			Paths:  []string{"/"},
+			Ignore: []string{"vendor"},
+			Exts:   []string{"go"},
+		},
+		base:    "/go/project",
+		watcher: &fileWatcherMock{},
+		init:    true,
+	}
+
+	files := []struct {
+		Path  string
+		IsDir bool
+	}{
+		// valid files
+		{"/go/project", true},
+		{"/go/project/main.go", false},
+		{"/go/project/main_test.go", false},
+		// invalid relative path
+		{"./relative/path", true},
+		{"./relative/path/file.go", false},
+		// invalid extension
+		{"/go/project/settings.yaml", false},
+		// invalid vendor files
+		{"/go/project/vendor/foo", true},
+		{"/go/project/vendor/foo/main.go", false},
+	}
+
+	for _, file := range files {
+		fileInfo := fileInfoMock{
+			FileIsDir: file.IsDir,
+		}
+		err := p.walk(file.Path, &fileInfo, nil)
+		if err != nil {
+			t.Errorf("Error not expected: %s", err)
+		}
+	}
+
+	if p.files != 2 {
+		t.Errorf("Exepeted %d files, but was %d", 2, p.files)
+	}
+
+	if p.folders != 1 {
+		t.Errorf("Exepeted %d folders, but was %d", 2, p.folders)
+	}
+}


### PR DESCRIPTION
I am trying to use the realize in one personal project, but I'm using the [Go version manager (GVM)](https://github.com/moovweb/gvm) too. The GVM uses GOPATH inside of one hidden folder `.gvm`, something like this: 
```
/home/user/.gvm/pkgsets/go1.9/global/src/my_package
```
And the realize ignore all hidden folders. I'm really sad about it. This restriction exists for a specific reason?