### PR TITLE
Remove check duplicate same path

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -43,9 +43,6 @@ func split(args, fields []string) []string {
 // Duplicates check projects with same name or same combinations of main/path
 func duplicates(value Project, arr []Project) (Project, error) {
 	for _, val := range arr {
-		if value.Path == val.Path {
-			return val, errors.New("There is already a project with path '" + val.Path + "'. Check your config file!")
-		}
 		if value.Name == val.Name {
 			return val, errors.New("There is already a project with name '" + val.Name + "'. Check your config file!")
 		}


### PR DESCRIPTION
I build my application as an executable command with cobra. So same path with different args could end up running 2 different things, so using path as a unique key when de-duplicating is a bad idea.