### PR TITLE
Fix ignored_paths

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -397,7 +397,8 @@ func (p *Project) tool(stop <-chan bool, path string) error {
 func (p *Project) walk(path string, info os.FileInfo, err error) error {
 	for _, v := range p.Watcher.Ignore {
 		s := append([]string{p.Path}, strings.Split(v, string(os.PathSeparator))...)
-		if strings.Contains(path, filepath.Join(s...)) {
+		absolutePath, _ := filepath.Abs(filepath.Join(s...))
+		if path == absolutePath || strings.HasPrefix(path, absolutePath+string(os.PathSeparator)) {
 			return nil
 		}
 	}

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -42,6 +42,7 @@ func TestWalk(t *testing.T) {
 		{"/go/project", true},
 		{"/go/project/main.go", false},
 		{"/go/project/main_test.go", false},
+		{"/go/project/vendorish/foo", true},
 		// invalid relative path
 		{"./relative/path", true},
 		{"./relative/path/file.go", false},
@@ -66,7 +67,7 @@ func TestWalk(t *testing.T) {
 		t.Errorf("Exepeted %d files, but was %d", 2, p.files)
 	}
 
-	if p.folders != 1 {
+	if p.folders != 2 {
 		t.Errorf("Exepeted %d folders, but was %d", 2, p.folders)
 	}
 }


### PR DESCRIPTION
Hello.
First of all thank you so much for this project, it's awesome.

I found and fix a bug in the `ignored_paths` feature.

If I say that `vendor` shoud be ignored, it will also ignore all paths that contains vendor. IE: `vendorish`.
It's not that bad in this case, but let say I have a folder `b`, and I add it to the ignored_paths, it will ignore all the paths that contains `b`, which is most probably all the paths.
For example: `/Users/agil**b**ert/go/src/project/pkg` would be ignored because of the `b` in my name.

So I changed the "contains" for a new condition that verify that the absolute path is equal, or that the path starts with the absolute path of the file plus a separator.

I found the bug because I ignored `bin` and realized later that `pkg/someLib/bindata` was ignored !