### PR TITLE
Bug fix - check error right away

### DIFF
--- a/realize/projects.go
+++ b/realize/projects.go
@@ -364,10 +364,10 @@ func (p *Project) Validate(path string, fcheck bool) bool {
 	// file check
 	if fcheck {
 		fi, err := os.Stat(path)
-		if !fi.IsDir() && ext(path) == "" {
+		if err != nil {
 			return false
 		}
-		if err != nil {
+		if !fi.IsDir() && ext(path) == "" {
 			return false
 		}
 		if fi.Size() > 0 {


### PR DESCRIPTION
Right now it panics if `os.Stat` returns error, instead of skipping the file.

To reproduce:
1. clone https://github.com/tmtx/realize_bug
2. run `realize start` using realize v2.0.1